### PR TITLE
[Feature] Alert componentize

### DIFF
--- a/Targets/MorningBearUI/Sources/Alert/Alertable.swift
+++ b/Targets/MorningBearUI/Sources/Alert/Alertable.swift
@@ -1,0 +1,34 @@
+//
+//  Alertable.swift
+//  MorningBearUI
+//
+//  Created by 이영빈 on 2022/12/06.
+//  Copyright © 2022 com.dache. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+public protocol Alertable {
+    var alertComponent: AlertComponent { get }
+}
+
+extension Alertable {
+    public var uiAlert: UIAlertController {
+        let controller = UIAlertController(title: self.alertComponent.title,
+                                           message: self.alertComponent.message,
+                                           preferredStyle: .alert)
+        
+        if let buttons = alertComponent.buttons {
+            buttons.forEach { controller.addAction($0) }
+        }
+        
+        return controller
+    }
+}
+
+public struct AlertComponent {
+    var title: String
+    var message: String?
+    var buttons: [UIAlertAction]?
+}

--- a/Targets/MorningBearUI/Sources/Alert/Extensions/Error + Extension.swift
+++ b/Targets/MorningBearUI/Sources/Alert/Extensions/Error + Extension.swift
@@ -1,0 +1,28 @@
+//
+//  File.swift
+//  MorningBearUI
+//
+//  Created by 이영빈 on 2022/12/06.
+//  Copyright © 2022 com.dache. All rights reserved.
+//
+
+import UIKit
+
+extension Error {
+    // Help turning Error into Alertable
+    var alertify: some Alertable {
+        return ErrorAlert(self)
+    }
+}
+
+fileprivate struct ErrorAlert<T>: Alertable where T: Error {
+    private let error: T
+    let alertComponent: AlertComponent
+    
+    init(_ error: T) {
+        self.error = error
+        self.alertComponent = AlertComponent(title: "에러 발생",
+                                             message: "\(error.localizedDescription)",
+                                             buttons: [UIAlertAction(title: "OK", style: .default)])
+    }
+}

--- a/Targets/MorningBearUI/Sources/Alert/Extensions/UIViewController + Extension.swift
+++ b/Targets/MorningBearUI/Sources/Alert/Extensions/UIViewController + Extension.swift
@@ -1,0 +1,21 @@
+//
+//  UIViewController + Extension.swift
+//  MorningBearUI
+//
+//  Created by 이영빈 on 2022/12/06.
+//  Copyright © 2022 com.dache. All rights reserved.
+//
+
+import UIKit
+
+extension UIViewController {
+    public func showAlert(_ error: some Error) {
+        let alert = error.alertify.uiAlert
+        self.present(alert, animated: true)
+    }
+    
+    public func showAlert(_ component: some Alertable) {
+        let alert = component.uiAlert
+        self.present(alert, animated: true)
+    }
+}

--- a/Targets/MorningBearUI/Tests/AlertableTests.swift
+++ b/Targets/MorningBearUI/Tests/AlertableTests.swift
@@ -1,0 +1,29 @@
+//
+//  AlertableTests.swift
+//  MorningBearUITests
+//
+//  Created by 이영빈 on 2022/12/06.
+//  Copyright © 2022 com.dache. All rights reserved.
+//
+
+import XCTest
+import UIKit
+
+@testable import MorningBearUI
+
+final class AlertableTests: XCTestCase {
+    func test__alertifying_error() throws {
+        let alertifiedError = MockError.seriousError.alertify
+        XCTAssert((alertifiedError as Any) is Alertable)
+    }
+}
+
+// MARK: Internal tools for testing
+fileprivate struct MockStruct: Alertable {
+    let alertComponent = AlertComponent(title: "Mock title")
+}
+
+fileprivate enum MockError: Error {
+    case seriousError
+}
+

--- a/Targets/MorningBearUI/Tests/MorningBearUITests.swift
+++ b/Targets/MorningBearUI/Tests/MorningBearUITests.swift
@@ -1,8 +1,0 @@
-import Foundation
-import XCTest
-
-final class MorningBearUITests: XCTestCase {
-    func test_example() {
-        XCTAssertEqual("MorningBearUI", "MorningBearUI")
-    }
-}


### PR DESCRIPTION
### 개요
`UIAlertController`를 래핑해서 여러가지 에러(혹은 이벤트)를 처리할 수 있게 공유 컴포넌트화 진행. 필요할 때마다 매번 반복생성하는 걸 줄이기 위함


### `Alertable`
일반 구조체에 사용 예시

```Swift
fileprivate struct MockStruct: Alertable {
    let alertComponent = AlertComponent(title: "Mock title",
                                        message: "mock message",
                                        buttons: [
                                            UIAlertAction(title: "Mock action 1",
                                                          style: .default,
                                                          handler: { _ in
                                                              print("Action 1")
                                                          }),
                                            UIAlertAction(title: "Mock action 2",
                                                          style: .cancel,
                                                          handler: { _ in
                                                              print("Action 2")
                                                          }),
                                            UIAlertAction(title: "Mock action 3",
                                                          style: .destructive,
                                                          handler: { _ in
                                                              print("Action 3")
                                                          })
                                        ]
    )
}
```

### 사용(working)
``` Swift
let vc = SomeUIViewController()

vc.showAlert(SomeError.failToLoad)
vc.showAlert(MockStruct())
```
#### 이렇게 쓸 수 있을지도
``` Swift
let vc = SomeUIViewController()

Network.shared.apolloTest.rx.fetch(query: FindLoginInfoQuery())
    .catch({ error in 
        vc.showAlert(error) 
    })
    .subscribe(
        onSuccess: { data in
            print(data.data?.findLoginInfo as Any)
        }, onFailure: { error in
            print("TEST: Error", error.localizedDescription)
        })
    .disposed(by: bag)
```